### PR TITLE
Add mobile nav dropdown and disable tilt on narrow screens

### DIFF
--- a/CSS/game.css
+++ b/CSS/game.css
@@ -306,3 +306,18 @@ body {
   50%  { background: #EF017C; }
   100% { width: 40px; height: 40px; }
 }
+
+/* Scale game container on small screens */
+@media (max-width: 700px) {
+  #gameContainer {
+    transform: scale(0.8);
+    transform-origin: top left;
+  }
+}
+
+@media (max-width: 500px) {
+  #gameContainer {
+    transform: scale(0.6);
+    transform-origin: top left;
+  }
+}

--- a/CSS/style.css
+++ b/CSS/style.css
@@ -37,6 +37,16 @@ nav {
   border-bottom-right-radius: 1rem;
 }
 
+nav .menu-btn {
+  display: none;
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 2rem;
+  margin-left: 1rem;
+  cursor: pointer;
+}
+
 nav ul li a {
   color: #fff;
   font-size: 1.25rem;
@@ -287,5 +297,60 @@ nav ul li a:hover {
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
+  }
+}
+
+/* Responsive adjustments for small screens */
+@media (max-width: 640px) {
+  nav {
+    height: 4rem;
+  }
+
+  nav .menu-btn {
+    display: block;
+  }
+
+  nav ul {
+    display: none;
+    flex-direction: column;
+    position: absolute;
+    top: 4rem;
+    left: 0;
+    width: 100%;
+    background: rgba(17,24,39,0.95);
+    padding: 0.5rem 0;
+    gap: 0.25rem;
+  }
+
+  nav.open ul {
+    display: flex;
+  }
+
+  nav ul {
+    padding: 0 0.5rem;
+  }
+
+  nav ul li a {
+    font-size: 1rem;
+    padding: 0.5rem 0.5rem;
+  }
+
+  #welcome .tilt {
+    font-size: 2.5rem;
+  }
+
+  #certifications,
+  #contact {
+    height: auto;
+    padding-top: 4rem;
+  }
+
+  .back-to-top {
+    right: 1rem;
+    bottom: 1rem;
+    width: 2.5rem;
+    height: 2.5rem;
+    font-size: 1.25rem;
+    line-height: 2.5rem;
   }
 }

--- a/Html/home.html
+++ b/Html/home.html
@@ -15,6 +15,7 @@
 </head>
 <body class="fade-in relative overflow-x-hidden text-white">
   <nav class="fixed top-0 w-full h-16 bg-gray-900/90 backdrop-blur flex items-center z-30">
+    <button id="menu-btn" class="menu-btn" aria-label="Toggle navigation">&#9776;</button>
     <ul class="flex justify-center w-full space-x-12">
       <li><a href="#welcome" data-item="Home">Home</a></li>
       <li><a href="#certifications" data-item="Certifications">Certifications</a></li>
@@ -91,6 +92,11 @@
         document.body.classList.add('fade-out');
         setTimeout(()=>window.location=gameLink.href,300);
       });
+
+      const menuBtn=document.getElementById('menu-btn');
+      const nav=document.querySelector('nav');
+      menuBtn.addEventListener('click',()=>nav.classList.toggle('open'));
+      nav.querySelectorAll('a').forEach(a=>a.addEventListener('click',()=>nav.classList.remove('open')));
     });
   </script>
   <script>

--- a/Javascript/home.js
+++ b/Javascript/home.js
@@ -45,7 +45,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
   document.querySelectorAll('.section').forEach(sec => observer.observe(sec));
 
-  const enableTilt = window.matchMedia('(hover: hover)').matches;
+  const enableTilt = window.matchMedia('(hover: hover)').matches && window.innerWidth > 640;
   if (enableTilt) {
     VanillaTilt.init(document.querySelectorAll('.tilt'), {
       max: 15,


### PR DESCRIPTION
## Summary
- introduce hamburger button for navigation on phones
- style responsive dropdown menu and show/hide via JS
- disable tilt effect when the viewport is under 640px

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686c14e4cc9883328427c362de02630b