### PR TITLE
Add Data Analysis with Python certification

### DIFF
--- a/CSS/style.css
+++ b/CSS/style.css
@@ -169,7 +169,7 @@ nav ul li a:hover {
 }
 
 #certifications {
-  height: 100vh;
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/Html/home.html
+++ b/Html/home.html
@@ -42,7 +42,7 @@
   </section>
   <section id="certifications" class="section flex flex-col items-center justify-center bg-gray-900 min-h-screen py-20">
     <h2 class="text-4xl font-bold mb-12">Certifications</h2>
-    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4 sm:gap-6 lg:gap-8 px-4 max-w-7xl">
+    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-7 gap-4 sm:gap-6 lg:gap-8 px-4 max-w-7xl">
       <div class="cert-card fill">
         <img loading="lazy" src="../Images/Screenshot 2025-06-25 195238.png" class="rounded mb-4 border border-gray-600"/>
         <a href="https://www.freecodecamp.org/certification/MarioUushunga/responsive-web-design" class="cert-link" data-item="Responsive Web Design" target="_blank" rel="noopener noreferrer">Responsive Web Design</a>
@@ -66,6 +66,10 @@
       <div class="cert-card fill">
         <img loading="lazy" src="../Images/Screenshot 2025-08-16 211340.png" class="rounded mb-4 border border-gray-600"/>
         <a href="https://www.freecodecamp.org/certification/mariouushunga/scientific-computing-with-python-v7" class="cert-link" data-item="Scientific Computing with Python" target="_blank" rel="noopener noreferrer">Scientific Computing with Python</a>
+      </div>
+      <div class="cert-card fill">
+        <img loading="lazy" src="../Images/Screenshot 2025-08-18 133512.png" class="rounded mb-4 border border-gray-600"/>
+        <a href="https://www.freecodecamp.org/certification/mariouushunga/data-analysis-with-python-v7" class="cert-link" data-item="Data Analysis with Python" target="_blank" rel="noopener noreferrer">Data Analysis with Python</a>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- add Data Analysis with Python certification card and link
- expand certification grid to 7 columns on large screens
- allow certifications section to grow with content

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a320bb82d48332b6ab46d8d7c1f21a