### PR TITLE
Improve responsive certifications layout

### DIFF
--- a/Html/home.html
+++ b/Html/home.html
@@ -42,33 +42,33 @@
   </section>
   <section id="certifications" class="section flex flex-col items-center justify-center bg-gray-900 min-h-screen py-20">
     <h2 class="text-4xl font-bold mb-12">Certifications</h2>
-    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-7 gap-4 sm:gap-6 lg:gap-8 px-4 max-w-7xl">
+    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-4 sm:gap-6 lg:gap-8 px-4 w-full max-w-5xl">
       <div class="cert-card fill">
-        <img loading="lazy" src="../Images/Screenshot 2025-06-25 195238.png" class="rounded mb-4 border border-gray-600"/>
+        <img loading="lazy" src="../Images/Screenshot 2025-06-25 195238.png" class="rounded mb-4 border border-gray-600 w-full"/>
         <a href="https://www.freecodecamp.org/certification/MarioUushunga/responsive-web-design" class="cert-link" data-item="Responsive Web Design" target="_blank" rel="noopener noreferrer">Responsive Web Design</a>
       </div>
       <div class="cert-card fill">
-        <img loading="lazy" src="../Images/Screenshot 2025-06-25 195320.png" class="rounded mb-4 border border-gray-600"/>
+        <img loading="lazy" src="../Images/Screenshot 2025-06-25 195320.png" class="rounded mb-4 border border-gray-600 w-full"/>
         <a href="https://www.freecodecamp.org/certification/MarioUushunga/javascript-algorithms-and-data-structures-v8" class="cert-link" data-item="JS Algorithms & Data Structures" target="_blank" rel="noopener noreferrer">JS Algorithms & Data Structures</a>
       </div>
       <div class="cert-card fill">
-        <img loading="lazy" src="../Images/Screenshot 2025-06-25 195345.png" class="rounded mb-4 border border-gray-600"/>
+        <img loading="lazy" src="../Images/Screenshot 2025-06-25 195345.png" class="rounded mb-4 border border-gray-600 w-full"/>
         <a href="https://www.freecodecamp.org/certification/MarioUushunga/front-end-development-libraries" class="cert-link" data-item="Front End Development Libraries" target="_blank" rel="noopener noreferrer">Front End Development Libraries</a>
       </div>
       <div class="cert-card fill">
-        <img loading="lazy" src="../Images/Screenshot 2025-06-25 195411.png" class="rounded mb-4 border border-gray-600"/>
+        <img loading="lazy" src="../Images/Screenshot 2025-06-25 195411.png" class="rounded mb-4 border border-gray-600 w-full"/>
         <a href="https://www.freecodecamp.org/certification/MarioUushunga/data-visualization" class="cert-link" data-item="Data Visualization" target="_blank" rel="noopener noreferrer">Data Visualization</a>
       </div>
       <div class="cert-card fill">
-        <img loading="lazy" src="../Images/Screenshot 2025-07-27 205019.png" class="rounded mb-4 border border-gray-600"/>
+        <img loading="lazy" src="../Images/Screenshot 2025-07-27 205019.png" class="rounded mb-4 border border-gray-600 w-full"/>
         <a href="https://www.freecodecamp.org/certification/MarioUushunga/back-end-development-and-apis" class="cert-link" data-item="Back End Development &amp; APIs" target="_blank" rel="noopener noreferrer">Back End Development &amp; APIs</a>
       </div>
       <div class="cert-card fill">
-        <img loading="lazy" src="../Images/Screenshot 2025-08-16 211340.png" class="rounded mb-4 border border-gray-600"/>
+        <img loading="lazy" src="../Images/Screenshot 2025-08-16 211340.png" class="rounded mb-4 border border-gray-600 w-full"/>
         <a href="https://www.freecodecamp.org/certification/mariouushunga/scientific-computing-with-python-v7" class="cert-link" data-item="Scientific Computing with Python" target="_blank" rel="noopener noreferrer">Scientific Computing with Python</a>
       </div>
       <div class="cert-card fill">
-        <img loading="lazy" src="../Images/Screenshot 2025-08-18 133512.png" class="rounded mb-4 border border-gray-600"/>
+        <img loading="lazy" src="../Images/Screenshot 2025-08-18 133512.png" class="rounded mb-4 border border-gray-600 w-full"/>
         <a href="https://www.freecodecamp.org/certification/mariouushunga/data-analysis-with-python-v7" class="cert-link" data-item="Data Analysis with Python" target="_blank" rel="noopener noreferrer">Data Analysis with Python</a>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Reconfigure certifications section to display in two rows with a responsive grid
- Expand certificate images to fill available card width for better readability

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a32435403c8332afa896ab6ff9257e